### PR TITLE
Use resolved name already in provisions list instead of private method

### DIFF
--- a/lib/orchestra/dsl/operations.rb
+++ b/lib/orchestra/dsl/operations.rb
@@ -89,9 +89,10 @@ module Orchestra
         end
 
         def finally name = :__finally__, &block
-          @builder.add_step name, &block
+          step = @builder.add_step name, &block
           @builder.command = true
-          self.result = name
+          resolved_name = step.provisions.fetch 0
+          self.result = resolved_name
         end
       end
     end

--- a/test/unit/dsl_test.rb
+++ b/test/unit/dsl_test.rb
@@ -127,4 +127,28 @@ class DSLTest < Minitest::Test
 
     assert_equal "Supplied block to Conductor.new; did you mean to invoke Orchestra::Operation.new do … end?", error.message
   end
+
+  def test_finally_for_modularized_object_steps
+    operation = Orchestra::Operation.new do
+      finally ExampleModule::AddFooToList
+    end
+
+    ary = []
+    Orchestra.execute operation, :list => ary
+    assert_equal [:foo], ary
+  end
+
+  private
+
+  module ExampleModule
+    class AddFooToList
+      def initialize list:
+        @list = list
+      end
+
+      def execute
+        @list << :foo
+      end
+    end
+  end
 end


### PR DESCRIPTION
I realized the name was already being resolved up the stack and I have access, so there's no need for the `Context#resolve` helper. Great codebase, @ntl. I'm learning more and more about it.